### PR TITLE
Set the base conditions mentions in COMPILING.md

### DIFF
--- a/pkg/buildbuild/config.go
+++ b/pkg/buildbuild/config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 	"strings"
 )
 
@@ -119,6 +120,13 @@ func (ops *GlobalOps) DefaultConfig() {
 	ops.Config.CompilerRuleDir = "$buildtooldir/rules/compiler"
 	ops.Config.FlavorRuleDir = "$buildtooldir/rules/flavor"
 	ops.Config.CompilerFlavorRuleDir = "$buildtooldir/rules/compiler-flavor"
+
+	ops.Config.Conditions[runtime.GOOS] = true
+	if runtime.GOARCH == "amd64" {
+		ops.Config.Conditions["x86_64"] = true
+	} else {
+		ops.Config.Conditions[runtime.GOARCH] = true
+	}
 
 	ops.FlavorConfigs = make(map[string]*FlavorConfig)
 }

--- a/pkg/buildbuild/config_test.go
+++ b/pkg/buildbuild/config_test.go
@@ -5,6 +5,7 @@ package buildbuild
 import (
 	"io/ioutil"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -55,9 +56,14 @@ compiler[cc2]
 	ops := NewGlobalOps()
 	ops.ParseConfig("", s, nil)
 
+	march := runtime.GOARCH
+	if march == "amd64" {
+		march = "x86_64"
+	}
+
 	c := &ops.Config
 	e := &Config{
-		Conditions:            map[string]bool{"pbuild": true},
+		Conditions:            map[string]bool{"pbuild": true, runtime.GOOS: true, march: true},
 		Buildparams:           nil,
 		AllFlavors:            map[string]bool{"a": true, "b": true, "c": true},
 		ActiveFlavors:         []string{"a", "b", "c"},


### PR DESCRIPTION
It seems these were lost as some point, now they're back, using the
value from Go runtime. I'm not completely sure the values match what
uname outputs in all cases, but we will have to fix those as we go.