### PR TITLE
Add default ruledeps for in.conf and buildvars copts for linkers.

### DIFF
--- a/pkg/buildbuild/config.go
+++ b/pkg/buildbuild/config.go
@@ -128,6 +128,8 @@ func (ops *GlobalOps) DefaultConfig() {
 		ops.Config.Conditions[runtime.GOARCH] = true
 	}
 
+	ops.Config.Ruledeps["in"] = []string{"$inconf", "$intool", "$configvars"}
+
 	ops.FlavorConfigs = make(map[string]*FlavorConfig)
 }
 

--- a/pkg/buildbuild/config_test.go
+++ b/pkg/buildbuild/config_test.go
@@ -74,12 +74,15 @@ compiler[cc2]
 		CompilerRuleDir:       "$buildtooldir/rules/compiler",
 		FlavorRuleDir:         "$buildtooldir/rules/flavor",
 		CompilerFlavorRuleDir: "$buildtooldir/rules/compiler-flavor",
-		Ruledeps:              map[string][]string{"q": []string{"qtool", "ztool", "xtool"}},
-		Buildvars:             []string{"foo2", "foo"},
-		Compiler:              []string{"cc", "cc2"},
-		BuildversionScript:    "bv.sh",
-		Buildpath:             "buildpath",
-		ConfigScript:          "./config_script.sh",
+		Ruledeps: map[string][]string{
+			"q":  []string{"qtool", "ztool", "xtool"},
+			"in": []string{"$inconf", "$intool", "$configvars"},
+		},
+		Buildvars:          []string{"foo2", "foo"},
+		Compiler:           []string{"cc", "cc2"},
+		BuildversionScript: "bv.sh",
+		Buildpath:          "buildpath",
+		ConfigScript:       "./config_script.sh",
 	}
 
 	if !reflect.DeepEqual(c, e) {

--- a/pkg/buildbuild/linker.go
+++ b/pkg/buildbuild/linker.go
@@ -41,7 +41,7 @@ type ParseLinkerParam func(l *LinkDesc, args []string)
 
 // Return keys handled by LinkDesc.Parse to pass to GenericParse
 func LinkerExtra(extra ...string) []string {
-	extra = append(extra, "incdirs", "no_analyse", "libs")
+	extra = append(extra, "incdirs", "no_analyse", "libs", "copts")
 	for k := range PluginLinkerParams {
 		extra = append(extra, k)
 	}
@@ -72,6 +72,10 @@ func (l *LinkDesc) LinkerParse(srcdir string, args map[string][]string) {
 
 	if args["no_analyse"] != nil {
 		l.NoAnalyse = true
+	}
+	if args["copts"] != nil {
+		// Is this cheating? I think it's ok.
+		l.Buildvars["copts"] = append(l.Buildvars["copts"], args["copts"]...)
 	}
 
 	l.Libs = append(l.Libs, args["libs"]...)


### PR DESCRIPTION
Both of these are mentioned in COMPILING.md and should be working
without needing to set them up in CONFIG. Now they're enabled by
default.