### PR TITLE
Fix go tool cover running from outside of gopath on files inside it.

### DIFF
--- a/internal/tools/gobuild.sh
+++ b/internal/tools/gobuild.sh
@@ -26,7 +26,7 @@ mode="$7"
 pkgdir="$8"
 
 
-ABSIN="$(cd "${IN:-.}" ; pwd)"
+ABSIN="$(cd "${IN:-.}" 2>/dev/null ; pwd)"
 
 # Convert relative paths to absolute, since go will change directory.
 CGO_CFLAGS=""
@@ -84,6 +84,9 @@ if [ "$mode" = "bench" ]; then
 	exec go test $PKG -bench $4
 fi
 if [ "$mode" = "cover_html" ]; then
+	# If we have a GOPATH then disable go modules or go 1.11 might fail
+	# to find the package due to assuming it to on based on $PWD.
+	[ -n "$GOPATH" ] && export GO111MODULE=off
 	exec go tool cover -html=$IN -o "$OUT"
 fi
 


### PR DESCRIPTION
The go cover file has always been a bit weird in my opinion when it
states the package path rather than the file path. In this case that
fails if we run go 1.11 from outside $GOPATH/src since it will assume
that modules are in use then, even though they're not.

We might want to require modules later, but I don't think we'll do that
before go 1.12 is released so for now disable the modules when we detect
this condition.