### PR TITLE
Allow libs to change the linker used.

### DIFF
--- a/pkg/buildbuild/lib.go
+++ b/pkg/buildbuild/lib.go
@@ -14,6 +14,7 @@ type LibDescriptor interface {
 	NameAsLib() (name string, islib bool)
 	NameAsPiclib() (name string, islib bool)
 	LibDeps() []string
+	Linker() string
 }
 
 type LibDesc struct {
@@ -109,6 +110,10 @@ func (l *LibDesc) NameAsPiclib() (string, bool) {
 
 func (l *LibDesc) LibDeps() []string {
 	return l.Libs
+}
+
+func (l *LibDesc) Linker() string {
+	return l.Link
 }
 
 var LibTemplate = LibDesc{
@@ -232,4 +237,17 @@ func (ops *GlobalOps) ResolveLibsOurPicAsLib(libs []string) ([]string, []string)
 		}
 	}
 	return objs, llibs
+}
+
+func (ops *GlobalOps) ResolveLibsLinker(link string, libs []string) string {
+	for _, lib := range ops.ResolveLibsOur(libs) {
+		llink := lib.Linker()
+		if llink != "link" && llink != "" && llink != link {
+			if link != "link" && link != "" {
+				panic("Multiple custom linkers, got " + link + " and " + llink)
+			}
+			link = llink
+		}
+	}
+	return link
 }

--- a/pkg/buildbuild/module.go
+++ b/pkg/buildbuild/module.go
@@ -31,8 +31,9 @@ func (m *ModuleDesc) Finalize(ops *GlobalOps) {
 	objs = append(objs, ops.ResolveLibsOurPic(m.Libs)...)
 
 	ldlibs := ops.ResolveLibsExternal(m.Libs)
+	link := ops.ResolveLibsLinker(m.Link, m.Libs)
 	eas := []string{"ldflags=-rdynamic -fPIC -shared", "ldlibs=" + strings.Join(ldlibs, " ")}
-	m.AddTarget(mod, m.Link, objs, m.Destdir, "", eas, m.TargetOptions)
+	m.AddTarget(mod, link, objs, m.Destdir, "", eas, m.TargetOptions)
 
 	m.FinalizeAnalyse(ops)
 	m.GeneralDesc.Finalize(ops)

--- a/pkg/buildbuild/prog.go
+++ b/pkg/buildbuild/prog.go
@@ -31,8 +31,9 @@ func (p *ProgDesc) Finalize(ops *GlobalOps) {
 	objs = append(objs, ops.ResolveLibsOurStatic(p.Libs)...)
 
 	ldlibs := ops.ResolveLibsExternal(p.Libs)
+	link := ops.ResolveLibsLinker(p.Link, p.Libs)
 	eas := []string{"ldlibs=" + strings.Join(ldlibs, " ")}
-	p.AddTarget(prog, p.Link, objs, p.Destdir, "", eas, p.TargetOptions)
+	p.AddTarget(prog, link, objs, p.Destdir, "", eas, p.TargetOptions)
 
 	p.FinalizeAnalyse(ops)
 	p.GeneralDesc.Finalize(ops)


### PR DESCRIPTION
If a lib contains C++ sources it should be linked using the C++ linker.
Now this will be propogated properly at least for local libaries.