### PR TITLE
Use /usr/bin/env to find bash.

### DIFF
--- a/internal/tools/gobuild.sh
+++ b/internal/tools/gobuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Schibsted
 
 # Brute force wrapper script to integrate building go code into our

--- a/internal/tools/ronn_wrapper.sh
+++ b/internal/tools/ronn_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Schibsted
 
 SRCFILE=$1

--- a/scripts/invars.sh
+++ b/scripts/invars.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Schibsted
 
 if [ $# -lt 1 ] ; then


### PR DESCRIPTION
Previously we assumed that it exists in /bin/, which is often but not
always the case. Some people might have newer versions installed in
other locations as well.