### PR TITLE
Add an enabled argument that can be used to enable/disable a descriptor.

### DIFF
--- a/docs/COMPILING.md
+++ b/docs/COMPILING.md
@@ -522,12 +522,22 @@ always `tool/`.
 
 ### Build descriptor arguments ###
 
+#### enabled ####
+
+Can be used to disable the descriptor unless a certain flavor or condition
+matches. Use with an empty value.
+
+E.g. `enabled::foo[]` will enable this describor if the `foo` condition is set,
+but it will otherwise be disabled. You can use enabled multiple times to
+specify different conditions.
+
 #### flavors ####
 
     flavors[dev]
 
 Limits the building of this descriptor to certain flavors. See below for more
-explaination of flavors.
+explaination of flavors. Superseded by the enabled argument which does much
+of the same and more.
 
 #### srcs ####
 

--- a/pkg/buildbuild/args.go
+++ b/pkg/buildbuild/args.go
@@ -33,7 +33,15 @@ var (
 	ConditionsNotAllowed = errors.New("Conditions are not allowed here")
 )
 
-func (args *Args) Parse(s *Scanner, conditions map[string]bool) {
+// Parse from s until a ) token is found, indicating the end of a descriptor.
+// Fills in *args with the arguments found, if the conditions set on the
+// argument match the ones given (if no conditions are set it's always a
+// match).
+//
+// Returns true if a `enabled` argument was found, regardless if it was saved
+// or not. Returning true and then not finding enabled in the arguments would
+// imply the descriptor should be skipped.
+func (args *Args) Parse(s *Scanner, conditions map[string]bool) (haveEnabled bool) {
 	*args = Args{
 		make(map[string][]string),
 		make(map[string]map[string][]string),
@@ -60,6 +68,9 @@ func (args *Args) Parse(s *Scanner, conditions map[string]bool) {
 				if !s.Scan() {
 					panicOrEOF(s)
 				}
+			}
+			if key == "enabled" {
+				haveEnabled = true
 			}
 		}
 		if s.Text() != "[" {
@@ -120,6 +131,7 @@ func (args *Args) Parse(s *Scanner, conditions map[string]bool) {
 		}
 	}
 	panicIfErr(s)
+	return
 }
 
 func CheckConditions(condstr string, conditions map[string]bool) bool {

--- a/pkg/buildbuild/args_test.go
+++ b/pkg/buildbuild/args_test.go
@@ -10,20 +10,21 @@ import (
 )
 
 type argTests struct {
-	input   string
-	expArgs *Args
-	expErr  error
+	haveEnabled bool
+	input       string
+	expArgs     *Args
+	expErr      error
 }
 
 var argstests = []argTests{
-	{``, &Args{}, nil},
-	{`)`, &Args{}, nil},
-	{`[]`, &Args{Unflavored: map[string][]string{"": []string{}}}, nil},
-	{`[foo]`, &Args{Unflavored: map[string][]string{"": []string{"foo"}}}, nil},
-	{`foo[bar baz] x[y]`, &Args{Unflavored: map[string][]string{
+	{false, ``, &Args{}, nil},
+	{false, `)`, &Args{}, nil},
+	{false, `[]`, &Args{Unflavored: map[string][]string{"": []string{}}}, nil},
+	{false, `[foo]`, &Args{Unflavored: map[string][]string{"": []string{"foo"}}}, nil},
+	{false, `foo[bar baz] x[y]`, &Args{Unflavored: map[string][]string{
 		"foo": []string{"bar", "baz"}, "x": []string{"y"},
 	}}, nil},
-	{`a[b] c:f[d] e::testcond[g] h::other[i] j:f:testcond,!other[k]`, &Args{Unflavored: map[string][]string{
+	{false, `a[b] c:f[d] e::testcond[g] h::other[i] j:f:testcond,!other[k]`, &Args{Unflavored: map[string][]string{
 		"a": []string{"b"}, "e": []string{"g"},
 	}, Flavored: map[string]map[string][]string{
 		"c": map[string][]string{"f": []string{"d"}},
@@ -33,7 +34,7 @@ var argstests = []argTests{
 			"c": []string{"d"}, "j": []string{"k"},
 		},
 	}}, nil},
-	{`a[b] a[c] a:f[d] a:f[e]`, &Args{Unflavored: map[string][]string{
+	{false, `a[b] a[c] a:f[d] a:f[e]`, &Args{Unflavored: map[string][]string{
 		"a": []string{"b", "c"},
 	}, Flavored: map[string]map[string][]string{
 		"a": map[string][]string{
@@ -44,27 +45,30 @@ var argstests = []argTests{
 			"a": []string{"d", "e"},
 		},
 	}}, nil},
-	{`foo`, nil, &ParseError{UnexpectedEOF, "", "test"}},
-	{`foo:`, nil, &ParseError{UnexpectedEOF, "", "test"}},
-	{`foo:bar`, nil, &ParseError{UnexpectedEOF, "", "test"}},
-	{`foo:bar:`, nil, &ParseError{UnexpectedEOF, "", "test"}},
-	{`foo:bar:baz`, nil, &ParseError{UnexpectedEOF, "", "test"}},
-	{`foo:bar:baz[`, nil, &ParseError{UnexpectedEOF, "", "test"}},
-	{`foo bar`, nil, &ParseError{MissingOpenBracket, "bar", "test"}},
-	{`a[b[]] b[c [ ] ] c[d[ ]]`, &Args{Unflavored: map[string][]string{
+	{false, `foo`, nil, &ParseError{UnexpectedEOF, "", "test"}},
+	{false, `foo:`, nil, &ParseError{UnexpectedEOF, "", "test"}},
+	{false, `foo:bar`, nil, &ParseError{UnexpectedEOF, "", "test"}},
+	{false, `foo:bar:`, nil, &ParseError{UnexpectedEOF, "", "test"}},
+	{false, `foo:bar:baz`, nil, &ParseError{UnexpectedEOF, "", "test"}},
+	{false, `foo:bar:baz[`, nil, &ParseError{UnexpectedEOF, "", "test"}},
+	{false, `foo bar`, nil, &ParseError{MissingOpenBracket, "bar", "test"}},
+	{false, `a[b[]] b[c [ ] ] c[d[ ]]`, &Args{Unflavored: map[string][]string{
 		"a": []string{"b[]"}, "b": []string{"c", "[", "]"}, "c": []string{"d[", "]"},
 	}}, nil},
+	{true, `enabled[]`, &Args{Unflavored: map[string][]string{
+		"enabled": []string{},
+	}}, nil},
+	{true, `enabled::none[]`, nil, nil},
 }
 
-func testParseArgs(args *Args, s *Scanner, conds map[string]bool) (err error) {
+func testParseArgs(args *Args, s *Scanner, conds map[string]bool) (haveEnabled bool, err error) {
 	defer func() {
 		p := recover()
 		if p != nil {
 			err = p.(error)
 		}
 	}()
-	args.Parse(s, conds)
-	return nil
+	return args.Parse(s, conds), nil
 }
 
 func TestArgs(t *testing.T) {
@@ -84,9 +88,11 @@ func TestArgs(t *testing.T) {
 			tst.expArgs.Flavors = make(map[string]map[string][]string)
 		}
 		s := NewScanner(ioutil.NopCloser(strings.NewReader(tst.input)), "test")
-		s.scannerSpecials = argsSpecials
 		var args Args
-		err := testParseArgs(&args, s, conds)
+		haveEnabled, err := testParseArgs(&args, s, conds)
+		if haveEnabled != tst.haveEnabled {
+			t.Error(tst.input, ": haveEnabled mismatch, got", haveEnabled)
+		}
 		if !reflect.DeepEqual(err, tst.expErr) {
 			if tst.expErr == nil {
 				t.Error(tst.input, ": Expected no error, got", err)

--- a/pkg/buildbuild/component.go
+++ b/pkg/buildbuild/component.go
@@ -90,7 +90,7 @@ func (dp *DescParser) Parse(srcdir string, s *Scanner, flavors []string) ParseFu
 	tname := s.Text()
 
 	var args Args
-	args.Parse(s, dp.Ops.Config.Conditions)
+	haveEnabled := args.Parse(s, dp.Ops.Config.Conditions)
 
 	if flavors == nil {
 		flavors = dp.Ops.Config.ActiveFlavors
@@ -114,6 +114,13 @@ func (dp *DescParser) Parse(srcdir string, s *Scanner, flavors []string) ParseFu
 		for k, v := range args.Flavors[fl] {
 			flargs[k] = append(flargs[k], v...)
 		}
+
+		// If an enabled argument exists then skip this descriptor if
+		// it's not currently set.
+		if _, ok := flargs["enabled"]; haveEnabled && !ok {
+			continue
+		}
+		delete(flargs, "enabled")
 
 		onlyForFlavors := flavors
 		if fl != "" {

--- a/test/Builddesc
+++ b/test/Builddesc
@@ -15,3 +15,14 @@ FOO(test
 		test_zlib_config:/dev/null:zlib.foo
 	]
 )
+
+FOO(enabled
+	enabled:regress[]
+	enabled:otherflavor[]
+	foos[foo.foo]
+)
+
+FOO(disabled
+	enabled:badflavor[]
+	foos[foo.foo]
+)

--- a/test/compile.sh
+++ b/test/compile.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Copyright 2018 Schibsted
 
-set -e
+set -xe
 test -z "$BUILDPATH" && BUILDPATH=build
 
 CC='env cc' seb -condition cfoo -condition cbar
@@ -26,5 +26,8 @@ if (ninja -f $BUILDPATH/build.ninja $BUILDPATH/regress/gocover/gopath-coverage.h
 touch go/src/gopath/main_test.go
 if ! (ninja -f $BUILDPATH/build.ninja $BUILDPATH/regress/gocover/gopath-coverage.html | grep -q 'coverage to') ; then echo "gopath-coverage.html not rebuilt with changes" ; exit 1 ; fi
 
+# Test of enabled argument
+test -f $BUILDPATH/obj/regress/lib/enabled
+! test -f $BUILDPATH/obj/regress/lib/disabled
 
 [ -n "$NODEPTEST" ] || CC='env cc' BUILDBUILD_ARGS="-condition cfoo -condition cbar" ../contrib/helpers/dep-tester.sh


### PR DESCRIPTION
This is more flexible than using the flavors argument, as it can be used
with conditionals as well, and you can setup multiple conditions for
when a descriptor is enabled or not.