### PR TITLE
Add enabled flavors and condition as comments to build.ninja.

### DIFF
--- a/docs/COMPILING.md
+++ b/docs/COMPILING.md
@@ -151,6 +151,9 @@ a target to rebuild the ninja files (with proper dependencies) and finally
 includes the flavors we'll build.  The default flavor is `dev`. A flavor is
 simply a named configuration, think 'dev' and 'release'.
 
+As a convenience, near the top it contains a comment with enabled flavors and
+conditions, allowing you to check that they match your expectations.
+
 The obj directory also contains a subdirectory for each flavor. In there the
 ninja files and intermediate build files are kept. More about that below.
 

--- a/pkg/buildbuild/output.go
+++ b/pkg/buildbuild/output.go
@@ -130,6 +130,14 @@ func (ops *GlobalOps) OutputTop() (err error) {
 	// Using bufio.Writer allows us to skip error checking until Flush.
 	w := bufio.NewWriter(topfile)
 
+	fmt.Fprintf(w, "# Flavors: %s\n", strings.Join(ops.Config.ActiveFlavors, ", "))
+	conds := make([]string, 0, len(ops.Config.Conditions))
+	for c := range ops.Config.Conditions {
+		conds = append(conds, c)
+	}
+	sort.Strings(conds)
+	fmt.Fprintf(w, "# Conditions: %s\n", strings.Join(conds, ", "))
+
 	// While we usually use $buildpath to refer to the top path
 	// ninja treats $builddir specially so set it as well.
 	fmt.Fprintf(w, "builddir=%s\n", toppath)

--- a/test/compile.sh
+++ b/test/compile.sh
@@ -8,6 +8,9 @@ CC='env cc' seb -condition cfoo -condition cbar
 touch Builddesc # to make ninja invoke seb.
 ninja -f $BUILDPATH/build.ninja
 
+grep '# Flavors: regress' $BUILDPATH/build.ninja
+grep '# Conditions:.*cbar, .*cbaz, .*cfoo' $BUILDPATH/build.ninja
+
 grep -q gopath $BUILDPATH/regress/collect_test/hejsan.txt
 grep -q gopath $BUILDPATH/regress/collect_test/other.txt
 grep -q bar $BUILDPATH/obj/regress/lib/test


### PR DESCRIPTION
This allows to easily inspect that comment to see that flavors and
conditions are as expected.