### PR TITLE
Skip GNU ld flags and objcopy usage on OS X.

### DIFF
--- a/rules/rules.ninja
+++ b/rules/rules.ninja
@@ -125,7 +125,7 @@ rule gobuild
     pool = gobuilds
 
 rule gobuildlib
-    command = GOPATH="$gopath" $buildtooldir/internal/tools/gobuild.sh "$gopkg" "$in" "$out" "$depfile" "$picflag -I $incdir $includes $platform_includes" "-L $libdir -L $scmcoord_contrib/lib $ldlibs" $gomode "$builddir" && objcopy --rename-section .init_array=go_init --globalize-symbol=_rt0_`go env GOARCH`_`go env GOOS`_lib "$out"
+    command = GOPATH="$gopath" $buildtooldir/internal/tools/gobuild.sh "$gopkg" "$in" "$out" "$depfile" "$picflag -I $incdir $includes $platform_includes" "-L $libdir -L $scmcoord_contrib/lib $ldlibs" $gomode "$builddir"
     depfile = $depfile
     description = building go library $out from $in
     pool = gobuilds


### PR DESCRIPTION
The --unresolved-symbols flags appears to be unneeded. I haven't been
able to find a proper way to disable the automatic loading of the Go
runtime on OS X. There might be a way but the symbol manipulation tools
seems slightly more limited than for ELF, so I'm not sure. I'm disabling
it for now (meaning you can't fork if you mix C and Go code).