### PR TITLE
Add goarch and goos arguments to GOPROG descriptor.

### DIFF
--- a/docs/descriptors/goprog.md
+++ b/docs/descriptors/goprog.md
@@ -16,7 +16,26 @@ argument](../arguments/extravars.md).
 Additionally, setting the `nocgo` [condition](../conditions.md) disables cgo
 for all programs.
 
-## Build some Other Package
+## Arguments
+
+### nocgo
+
+Use with an empty value, i.e. `nocgo[]`. Disables cgo for this binary.
+
+### goarch
+
+Sets the goarch to compile for, useful when compiling binaries that will be
+deployed. Commonly set together with goos for a specific flavor.
+Example:
+
+	goos:release[linux]
+	goarch:release[amd64]
+
+### goos
+
+Sets the goos to compile for. See [goarch](#goarch) for more information.
+
+### gopkg
 
 You can use GOPROG without having the go sources present in the same directory.
 If you use the `gopkg` argument that Go package will be compiled instead of the

--- a/internal/tools/gobuild.sh
+++ b/internal/tools/gobuild.sh
@@ -101,7 +101,7 @@ fi
 
 case "$mode" in
 	cover)
-		go test -coverprofile="$out" $PKG
+		go test $GOBUILD_FLAGS -coverprofile="$out" $GOBUILD_TEST_FLAGS $PKG
 	;;
 	prog-nocgo)
 		CGO_ENABLED=0

--- a/pkg/buildbuild/go.go
+++ b/pkg/buildbuild/go.go
@@ -6,8 +6,10 @@ import "strings"
 
 type GoProgDesc struct {
 	LinkDesc
-	Pkg   string
-	NoCgo bool
+	Pkg    string
+	NoCgo  bool
+	GOOS   string
+	GOARCH string
 }
 
 type GoTestDesc struct {
@@ -29,10 +31,12 @@ func (tmpl *GoTestDesc) NewFromTemplate(bd, tname string, flavors []string) Desc
 }
 
 func (g *GoProgDesc) Parse(ops *GlobalOps, realsrcdir string, args map[string][]string) Descriptor {
-	desc := g.GenericParse(g, ops, realsrcdir, args, LinkerExtra("gopkg", "nocgo"))
+	desc := g.GenericParse(g, ops, realsrcdir, args, LinkerExtra("gopkg", "nocgo", "goos", "goarch"))
 	g.LinkerParse(realsrcdir, args)
 	g.Pkg = strings.Join(args["gopkg"], " ")
 	g.NoCgo = args["nocgo"] != nil
+	g.GOOS = strings.Join(args["goos"], " ")
+	g.GOARCH = strings.Join(args["goarch"], " ")
 	return desc
 }
 
@@ -57,6 +61,12 @@ func (g *GoProgDesc) Finalize(ops *GlobalOps) {
 		eas = append(eas, "gomode=prog-nocgo")
 	} else {
 		eas = append(eas, "gomode=prog")
+	}
+	if g.GOOS != "" {
+		eas = append(eas, "goos="+g.GOOS)
+	}
+	if g.GOARCH != "" {
+		eas = append(eas, "goarch="+g.GOARCH)
 	}
 
 	target := g.AddTarget(g.TargetName, "gobuild", []string{g.Srcdir}, g.Destdir, "", eas, g.TargetOptions)

--- a/rules/rules.ninja
+++ b/rules/rules.ninja
@@ -126,13 +126,13 @@ pool gobuilds
 gobuild_tool=GOPATH="$gopath" GOBUILD_FLAGS=$gobuild_flags GOBUILD_TEST_FLAGS=$gobuild_test_flags CGO_ENABLED=$cgo_enabled $buildtooldir/internal/tools/gobuild.sh
 
 rule gobuild
-    command = $gobuild_tool "$gopkg" "$in" "$out" "$objdir/depfile-$gomode" "-I $incdir $includes $platform_includes" "-L $libdir -L $scmcoord_contrib/lib $ldlibs" $gomode "$builddir"
+    command = GOOS="$goos" GOARCH="$goarch" $gobuild_tool "$gopkg" "$in" "$out" "$objdir/depfile-$gomode" "-I $incdir $includes $platform_includes" "-L $libdir -L $scmcoord_contrib/lib $ldlibs" $gomode "$builddir"
     depfile = $objdir/depfile-$gomode
     description = building go program $out from $in
     pool = gobuilds
 
 rule gobuildlib
-    command = $gobuild_tool "$gopkg" "$in" "$out" "$depfile" "$picflag -I $incdir $includes $platform_includes" "-L $libdir -L $scmcoord_contrib/lib $ldlibs" $gomode "$builddir"
+    command = GOOS="$goos" GOARCH="$goarch" $gobuild_tool "$gopkg" "$in" "$out" "$depfile" "$picflag -I $incdir $includes $platform_includes" "-L $libdir -L $scmcoord_contrib/lib $ldlibs" $gomode "$builddir"
     depfile = $depfile
     description = building go library $out from $in
     pool = gobuilds

--- a/test/Builddesc
+++ b/test/Builddesc
@@ -1,6 +1,7 @@
 # Copyright 2018 Schibsted
 
 COMPONENT([
+	goarch
 	go/src/gopath
 	collect_special
 	srcdir

--- a/test/Builddesc.top
+++ b/test/Builddesc.top
@@ -1,7 +1,7 @@
 # Copyright 2018 Schibsted
 
 CONFIG(
-	flavors[regress]
+	flavors[regress prod]
 	configvars[config.ninja]
 	config_script[./config_script.sh]
 	rules[rules.ninja]

--- a/test/compile.sh
+++ b/test/compile.sh
@@ -8,13 +8,18 @@ CC='env cc' seb -condition cfoo -condition cbar
 touch Builddesc # to make ninja invoke seb.
 ninja -f $BUILDPATH/build.ninja
 
-grep '# Flavors: regress' $BUILDPATH/build.ninja
+grep '# Flavors: regress, prod' $BUILDPATH/build.ninja
 grep '# Conditions:.*cbar, .*cbaz, .*cfoo' $BUILDPATH/build.ninja
 
 grep -q gopath $BUILDPATH/regress/collect_test/hejsan.txt
 grep -q gopath $BUILDPATH/regress/collect_test/other.txt
 grep -q bar $BUILDPATH/obj/regress/lib/test
 grep -q fooval $BUILDPATH/regress/regress/infile/infile
+
+# Check regress flavor for darwin 386 build
+grep -q rt0_386_darwin $BUILDPATH/regress/bin/goarch
+# Check prod flavor is executable.
+$BUILDPATH/prod/bin/goarch
 
 ninja -f $BUILDPATH/build.ninja $BUILDPATH/regress/gotest/gopath
 ninja -f $BUILDPATH/build.ninja $BUILDPATH/regress/gocover/gopath-coverage.html

--- a/test/goarch/Builddesc
+++ b/test/goarch/Builddesc
@@ -1,0 +1,4 @@
+GOPROG(goarch
+	goarch:regress[386]
+	goos:regress[darwin]
+)

--- a/test/goarch/main.go
+++ b/test/goarch/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func main() {
+	fmt.Println(runtime.GOARCH)
+}


### PR DESCRIPTION
This allows sebuild to cross compile go programs. Useful for example for
packaging where the output is run on a completely different system.