### PR TITLE
Check that buildtooldir match previous run before executing ninja.

### DIFF
--- a/cmd/seb/main.go
+++ b/cmd/seb/main.go
@@ -115,7 +115,10 @@ func main() {
 			// we just exec ninja and let it re-invoke us if needed.
 			// If we get any errors here try the long path.
 			defer f.Close()
-			ours := []byte(fmt.Sprintf("# %s\n", buildbuild.BuildBuildArgs(os.Args)))
+			var ourb bytes.Buffer
+			fmt.Fprintf(&ourb, "# %s\n", buildbuild.BuildBuildArgs(os.Args))
+			fmt.Fprintf(&ourb, "# %s\n", buildbuild.BuildtoolDir())
+			ours := ourb.Bytes()
 			theirs := make([]byte, len(ours))
 			if _, err := io.ReadFull(f, theirs); err != nil {
 				return nil

--- a/pkg/buildbuild/globalops.go
+++ b/pkg/buildbuild/globalops.go
@@ -166,7 +166,7 @@ func (ops *GlobalOps) RegisterGlob(srcdir, src string) {
 
 func (ops *GlobalOps) ReExec() {
 	if _, ok := os.LookupEnv("BUILDTOOLDIR"); !ok {
-		btp := ops.BuildtoolDir()
+		btp := BuildtoolDir()
 		os.Setenv("BUILDTOOLDIR", btp)
 	}
 	binpath := filepath.Join(ops.Config.Buildpath, "obj", "_build_build")

--- a/pkg/buildbuild/output.go
+++ b/pkg/buildbuild/output.go
@@ -45,7 +45,7 @@ func (ops *GlobalOps) BuildtoolDir() string {
 
 // Buildtooldir figures out what directory contains the sebuild ninja runtime.
 // First it tries to import the go package and check for sources, if that
-// fails it looks for a directory based on the binary path. If that als fails
+// fails it looks for a directory based on the binary path. If that also fails
 // it checks $HOME/.seb/
 func BuildtoolDir() string {
 	if p := os.Getenv("BUILDTOOLDIR"); p != "" {

--- a/pkg/buildbuild/plugin.go
+++ b/pkg/buildbuild/plugin.go
@@ -85,7 +85,7 @@ func (ops *GlobalOps) RecompileWithPlugins() {
 			gofiles = append(gofiles, filepath.Join(mypkg.Dir, f))
 		}
 	} else {
-		d := ops.BuildtoolDir()
+		d := BuildtoolDir()
 		pattern := filepath.Join(d, "cmd", "seb", "*.go")
 		gofiles, err = filepath.Glob(pattern)
 		if err != nil {


### PR DESCRIPTION
A mismatch could for example happen when running docker and mapping the
local directory into the container, or in any other case when the same
directory is accessed from multiple environments.

With this fix we avoid this raising an error and make sure to regenerate
when a problem occurs.