### PR TITLE
Add a godeps_rule CONFIG argument to set the rule for godeps.

### DIFF
--- a/Builddesc.top
+++ b/Builddesc.top
@@ -2,6 +2,8 @@
 
 CONFIG(
 	config_script[scripts/seb_config.sh]
+	godeps[go.mod]
+	godeps_rule[touch]
 )
 
 COMPONENT([

--- a/docs/arguments/specialsrcs.md
+++ b/docs/arguments/specialsrcs.md
@@ -36,6 +36,11 @@ descriptor](../descriptors/config.md) via the `rules` argument there.
 
 Simply concatenates the sources into the target, can also be used to copy files.
 
+### touch
+
+Runs the touch command on the output file, ignores inputs. Useful for
+[godeps_rule](../descriptors/config.md#godeps-and-godeps_rule).
+
 ### gperf_switch
 
 The source should be a C or C++ file. Inside these you can have

--- a/docs/descriptors/config.md
+++ b/docs/descriptors/config.md
@@ -157,20 +157,23 @@ and `cwarnflags`.
 
 Defaults to the bundled `rules/flavor` directory.
 
-## godeps
+## godeps and godeps_rule
 A list of files that all Go target depends on. E.g. you can add go.mod
 here to rebuild all go targets when go.mod changes.
-For it to work, you must however also create a custom godeps rule, in
-case you wish to parse the input file in some matter. The simplest
-version of this rule just touches the output:
 
-```
-rule godeps
-    command = touch $out
-```
+By default this tries to execute a `godeps` rule, which you can define
+in a rules.ninja file. You can however also change the rule used with
+the `godeps_rule` argument. For simple cases the
+[touch](../arguments/specialsrcs.md#touch) rule should be suitable.
 
-You have to use the [rules](#rules) argument to name a file containing
-this rule. In the future this requirement might be made optional.
+For example
+
+	godeps[go.mod]
+	godeps_rule[touch]
+
+is enough to rebuild all Go targets when go.mod changes.
+
+In 2.0 `touch` will be made the default value for `godeps_rule`
 
 Empty list by default.
 

--- a/pkg/buildbuild/config.go
+++ b/pkg/buildbuild/config.go
@@ -81,10 +81,11 @@ type Config struct {
 	FlavorRuleDir         string
 	CompilerFlavorRuleDir string
 
-	Ruledeps  map[string][]string // Additional dependencies for particular rules.
-	Buildvars []string
-	Compiler  []string
-	Godeps    []string
+	Ruledeps   map[string][]string // Additional dependencies for particular rules.
+	Buildvars  []string
+	Compiler   []string
+	Godeps     []string
+	GodepsRule string
 
 	BuildversionScript string
 	Buildpath          string
@@ -120,6 +121,7 @@ func (ops *GlobalOps) DefaultConfig() {
 	ops.Config.CompilerRuleDir = "$buildtooldir/rules/compiler"
 	ops.Config.FlavorRuleDir = "$buildtooldir/rules/flavor"
 	ops.Config.CompilerFlavorRuleDir = "$buildtooldir/rules/compiler-flavor"
+	ops.Config.GodepsRule = "godeps"
 
 	ops.Config.Conditions[runtime.GOOS] = true
 	if runtime.GOARCH == "amd64" {
@@ -223,6 +225,7 @@ func (ops *GlobalOps) ParseConfig(srcdir string, s *Scanner, flavors []string) P
 		{"compiler_rule_dir", &ops.Config.CompilerRuleDir},
 		{"flavor_rule_dir", &ops.Config.FlavorRuleDir},
 		{"compiler_flavor_rule_dir", &ops.Config.CompilerFlavorRuleDir},
+		{"godeps_rule", &ops.Config.GodepsRule},
 	} {
 		if args.Unflavored[conf.key] != nil {
 			*conf.conf = strings.Join(args.Unflavored[conf.key], " ")

--- a/pkg/buildbuild/config_test.go
+++ b/pkg/buildbuild/config_test.go
@@ -83,6 +83,7 @@ compiler[cc2]
 		BuildversionScript: "bv.sh",
 		Buildpath:          "buildpath",
 		ConfigScript:       "./config_script.sh",
+		GodepsRule:         "godeps",
 	}
 
 	if !reflect.DeepEqual(c, e) {

--- a/pkg/buildbuild/output.go
+++ b/pkg/buildbuild/output.go
@@ -204,7 +204,7 @@ func (ops *GlobalOps) OutputTop() (err error) {
 	}
 	fmt.Fprintf(w, "include $buildtooldir/rules/rules.ninja\n")
 	if len(ops.Config.Godeps) > 0 {
-		fmt.Fprintf(w, "build %s: godeps %s\n", ops.GodepsStamp(),
+		fmt.Fprintf(w, "build %s: %s %s\n", ops.GodepsStamp(), ops.Config.GodepsRule,
 			strings.Join(ops.Config.Godeps, " "))
 		mkpath(toppath, "obj/_go")
 	}

--- a/rules/rules.ninja
+++ b/rules/rules.ninja
@@ -86,6 +86,9 @@ rule concat
     command = cat $in > $out
     description = concatenate $in to $out
 
+rule touch
+    command = touch $out
+
 gperf_enum = $buildtooldir/internal/tools/gperf_enum.pl
 rule gperf_enum
     command = $gperf_enum $out $in


### PR DESCRIPTION
I was hoping to do this with a variable rather than a custom argument,
but I couldn't get it to work, it seems ninja doesn't allow variables
for the rule name.

While touch should be the default rule it wouldn't be backwards
compatible so keeping the godeps default for now.