### PR TITLE
Allow sebuild to work across go module boundaries.

### DIFF
--- a/docs/descriptors/gotest.md
+++ b/docs/descriptors/gotest.md
@@ -35,3 +35,7 @@ As an advanced feature, GOTEST targets are also automatically collected in
 variables, see the
 [collect_target_var argument](../arguments/collect-target-var.md) for more more
 information about this.
+
+Unfortunately, the go coverage html generating does not currently work in other
+go modules than the main one. There is no easy way to solve this so it's kept
+as a known issue.

--- a/internal/tools/gobuild.sh
+++ b/internal/tools/gobuild.sh
@@ -69,13 +69,6 @@ IFS="$orig_IFS"
 # Strip initial :
 GOPATH="${gopath:1}"
 
-# If we have an explicit GOPATH then disable go modules.
-# Probably will want to drop support for GOPATH quite soon, but that should be
-# a major release so it will have to wait for that.
-if [ -n "$GOPATH" ]; then
-	export GO111MODULE=off
-fi
-
 if [ -z "$mode" ]; then
 	mode="prog"
 fi
@@ -96,10 +89,18 @@ fi
 out="$(cd "$(dirname "$OUT")" ; pwd)/$(basename "$OUT")"
 depfile="$(cd "$(dirname "$DEPFILE")" ; pwd)/$(basename "$DEPFILE")"
 
-if [ -z "$PKG" ] && [ -n "$(cd "$ABSIN" 2>/dev/null && go env GOMOD 2>/dev/null)" ]; then
+
+# Using a relative path helps the error messages, since we don't have to
+# change the current directory, but it won't work if it's not within the
+# same module.
+gomod="$(go env GOMOD)"
+if [ -z "$PKG" ] && [ -n "$gomod" ] && [ "$(cd "$ABSIN" 2>/dev/null && go env GOMOD 2>/dev/null)" = "$gomod" ]; then
 	PKG="./$IN"
 fi
-[ -z "$PKG" ] && cd "$ABSIN" > /dev/null
+if [ -z "$PKG" ]; then
+	cd "$ABSIN" > /dev/null
+	echo "gobuild: Entering directory \`$ABSIN'"
+fi
 
 # Do the deps file async to speed it up slightly.
 # It's waited for at the end as long as the compile worked.

--- a/internal/tools/gobuild.sh
+++ b/internal/tools/gobuild.sh
@@ -82,6 +82,10 @@ if [ "$mode" = "bench" ]; then
 	exec go test $GOBUILD_FLAGS $GOBUILD_TEST_FLAGS $PKG -bench $4
 fi
 if [ "$mode" = "cover_html" ]; then
+	# On Go 1.11 and 1.12 only, auto modules might fail here due to being
+	# run from outside gopath but working on files inside. Go 1.11 is not
+	# supported.
+	[ -n "$GOPATH" ] && [ "${GO111MODULE:-auto}" = auto ] && [ "$(go version|cut -b 12-17)" = go1.12 ] && export GO111MODULE=off
 	exec go tool cover -html=$IN -o "$OUT"
 fi
 


### PR DESCRIPTION
It's sometimes useful to split a Go project into multiple Go modules to
split up the dependencies, e.g. for optional features having more
dependencies.

This can now be handled by sebuild by checking that we're staying in the
same go module when using relative paths, otherwise changing the current
directory first. Error messages should still be ok by printing the new
directory after changing it.

The fix for using gopath no longer seems necessary. Since it was also a
bit annoying, I remove it here.

A known issue is that coverage files still don't work across submodules,
since it can't find the right source file path. I don't see any easy
solution for that though.