### PR TITLE
Allow multiple targets in specialsrcs.

### DIFF
--- a/docs/arguments/specialsrcs.md
+++ b/docs/arguments/specialsrcs.md
@@ -18,6 +18,10 @@ up and do anything with the output from the script. You will need to specify
 additional arguments that use the output somehow, usually with
 [conf](../descriptors/install.md#conf) or [srcs](srcs.md).
 
+The target can also be a comma separated list. In that case a single command
+run should generate all the target files. The `$out` variable will have
+all the output files in it, in the same order.
+
 ## Special Commands
 
 Plugins are allowed to hijack specialsrcs by redirecting any specific commands

--- a/pkg/buildbuild/descriptor.go
+++ b/pkg/buildbuild/descriptor.go
@@ -46,6 +46,7 @@ type Descriptor interface {
 	CompileSrc(srcdir, src, srcbase, ext string)
 
 	AddTarget(tname, rule string, srcs []string, destdir, srcdir string, extraargs []string, options map[string]bool) *Target
+	AddMultiTarget(tnames []string, target *Target)
 	AllTargets() map[string]*Target
 
 	ResolveSrcs(ops *GlobalOps, tname string, srcs ...string) []string

--- a/test/Builddesc
+++ b/test/Builddesc
@@ -34,3 +34,10 @@ INSTALL(/regress/infile
 	conf[infile]
 	srcs[infile.in]
 )
+
+INSTALL(/regress/multitgt
+	conf[a b c]
+	specialsrcs[
+		check_order::a,b,c
+	]
+)

--- a/test/rules.ninja
+++ b/test/rules.ninja
@@ -13,3 +13,6 @@ depend_rule_echo_names=/dev/null
 rule echo_other
     command = for a in $other ; do echo $$a ; done | LANG=C sort > $out
 depend_rule_echo_names=/dev/null
+
+rule check_order
+    command = for f in $out ; do printf "%s\n" $out > $$f ; bash -c "diff -q <(sort $$f) $$f" ; done


### PR DESCRIPTION
Quite a few commands generate multiple output and this should make those
easier to work with, as long as they want the list on the commandline.

Since my first implementation ended up with an unstable order in the
$out variable I added a test for that.

The temporary target renaming interfered a bit, but I think I got the
parts right. The rename check is still done for each target name added,
even when they're part of a multi-target.