### PR TITLE
Add a stamp file and a touch tool.

### DIFF
--- a/cmd/seb/main.go
+++ b/cmd/seb/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/schibsted/sebuild/internal/cmd/link"
 	python_install "github.com/schibsted/sebuild/internal/cmd/python-install"
 	"github.com/schibsted/sebuild/internal/cmd/ronn"
+	"github.com/schibsted/sebuild/internal/cmd/touch"
 	"github.com/schibsted/sebuild/pkg/buildbuild"
 )
 
@@ -143,7 +144,7 @@ func main() {
 			if err != nil {
 				return nil
 			}
-			return RunNinja(ninja, bnpath)
+			return RunNinja(ninja, ops.Config.Buildpath)
 		}
 	}
 
@@ -176,8 +177,7 @@ func main() {
 		return
 	}
 
-	bnpath := filepath.Join(ops.Config.Buildpath, "build.ninja")
-	log.Fatal(RunNinja("", bnpath))
+	log.Fatal(RunNinja("", ops.Config.Buildpath))
 }
 
 func installTools(quiet bool) {
@@ -213,6 +213,8 @@ func mainTool() {
 		ronn.Main(os.Args[3:]...)
 	case "in":
 		in.Main(os.Args[3:]...)
+	case "touch":
+		touch.Main(os.Args[3:]...)
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown tool %q.\n", os.Args[2])
 		os.Exit(1)

--- a/cmd/seb/ninja.go
+++ b/cmd/seb/ninja.go
@@ -4,8 +4,10 @@ package main
 
 import (
 	"flag"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
 )
 
@@ -13,7 +15,7 @@ func FindNinja() (string, error) {
 	return exec.LookPath("ninja")
 }
 
-func RunNinja(ninja, bnpath string) error {
+func RunNinja(ninja, bp string) error {
 	if ninja == "" {
 		var err error
 		ninja, err = FindNinja()
@@ -21,6 +23,9 @@ func RunNinja(ninja, bnpath string) error {
 			return err
 		}
 	}
+	stamp := filepath.Join(bp, "stamp")
+	ioutil.WriteFile(stamp, nil, 0666)
+	bnpath := filepath.Join(bp, "build.ninja")
 	argv := append([]string{"ninja", "-f", bnpath}, flag.Args()...)
 	return syscall.Exec(ninja, argv, os.Environ())
 }

--- a/internal/cmd/touch/main.go
+++ b/internal/cmd/touch/main.go
@@ -1,0 +1,50 @@
+package touch
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+var (
+	flagset = flag.NewFlagSet("touch", flag.ExitOnError)
+	offset  = flagset.Duration("offset", 0, "Offset to add to the time set.")
+)
+
+func Main(args ...string) {
+	flagset.Usage = func() {
+		fmt.Fprintf(flagset.Output(), "Usage: %s -tool touch [options] <files...>\n", os.Args[0])
+		flagset.PrintDefaults()
+	}
+	flagset.Parse(args)
+	if flagset.NArg() == 0 {
+		flagset.Usage()
+		os.Exit(1)
+	}
+	ts := time.Now().Add(*offset)
+
+	ret := 0
+	for _, name := range flagset.Args() {
+		err := os.Chtimes(name, ts, ts)
+		if err != nil {
+			perr := err.(*os.PathError)
+			if perr.Err == syscall.ENOENT {
+				var f *os.File
+				f, err = os.OpenFile(name, os.O_WRONLY|os.O_CREATE, 0666)
+				if f != nil {
+					f.Close()
+				}
+				if err == nil {
+					err = os.Chtimes(name, ts, ts)
+				}
+			}
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %s\n", name, err)
+			ret = 1
+		}
+	}
+	os.Exit(ret)
+}

--- a/rules/rules.ninja
+++ b/rules/rules.ninja
@@ -59,11 +59,11 @@ rule yaccxx
     description = yacc $out
 
 rule install_conf
-    command = install -m0644 $in $out
+    command = install -p -m0644 $in $out
     description = copy $in to $out
 
 rule install_script
-    command = install -m0755 $in $out
+    command = install -p -m0755 $in $out
     description = copy $in to $out
 
 rule install_header

--- a/test/Builddesc
+++ b/test/Builddesc
@@ -30,6 +30,13 @@ FOO(disabled
 	foos[foo.foo]
 )
 
+INSTALL(/regress
+	conf[touchtest]
+	specialsrcs[
+		touch_plus5:$buildpath/stamp:touchtest
+	]
+)
+
 INSTALL(/regress/infile
 	conf[infile]
 	srcs[infile.in]

--- a/test/compile.sh
+++ b/test/compile.sh
@@ -43,4 +43,9 @@ if ! (ninja -f $BUILDPATH/build.ninja $BUILDPATH/regress/gocover/gopath-coverage
 test -f $BUILDPATH/obj/regress/lib/enabled
 ! test -f $BUILDPATH/obj/regress/lib/disabled
 
+# Test touching in future
+seb $BUILDPATH/regress/regress/touchtest
+sleep 1 # Bump stamp source.
+seb $BUILDPATH/regress/regress/touchtest | grep -q 'no work to do'
+
 [ -n "$NODEPTEST" ] || CC="cc -std=gnu11" BUILDBUILD_ARGS="-condition cfoo -condition cbar" ../contrib/helpers/dep-tester.sh

--- a/test/rules.ninja
+++ b/test/rules.ninja
@@ -13,3 +13,6 @@ depend_rule_echo_names=/dev/null
 rule echo_other
     command = for a in $other ; do echo $$a ; done | LANG=C sort > $out
 depend_rule_echo_names=/dev/null
+
+rule touch_plus5
+    command = seb -tool touch -offset 5s $out


### PR DESCRIPTION
It's sometimes useful to set an mtime to the future to avoid rebuilding
something until that timestamp passes. Typically needed when a file has
a builtin expiration timestamp such as a certificate.

For this to be possible sebuild now always creates a stamp file in
$buildpath with the current timestamp. The file can then use this as a
source or dependency to always be rebuilt when it's mtime passes the
current time.

Setting the timestamp to the future turned out to be difficult with the
defaul touch tool, there's no portable way. Because of that I decided to
write an internal tool for it, which turned out to be pretty trivial.