### PR TITLE
Exclude files in goroot and imported modules from depfile.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/schibsted/sebuild
 
 require github.com/go-bindata/go-bindata v1.0.0
+
+go 1.12

--- a/internal/cmd/gobuild/depfile.go
+++ b/internal/cmd/gobuild/depfile.go
@@ -3,27 +3,42 @@
 package gobuild
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
+	"go/build"
 	"os"
+	"path/filepath"
+	"runtime"
 )
 
 func writeDepfile(depf *os.File) error {
 	defer depf.Close()
 
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "%s: ", outpath)
 	err := runWithBuildFlagsAndPkg(&buf, "go", "list", "-deps", "-f", `{{$dir:=.Dir}}{{range .GoFiles}}{{$dir}}/{{.}} {{end}}{{range .CgoFiles}}{{$dir}}/{{.}} {{end}}{{range .HFiles}}{{$dir}}/{{.}} {{end}}{{range .CFiles}}{{$dir}}/{{.}} {{end}}{{range .TestGoFiles}}{{$dir}}/{{.}} {{end}}`)
 	if err != nil {
 		return err
 	}
-	deps := buf.Bytes()
-	for i, b := range deps {
-		if b == '\n' {
-			deps[i] = ' '
+
+	// Ignore files in GOROOT and in modules. These should not normally
+	// change, except on Go version upgrades, but I think it's a fair trade
+	// with dependency size to have to manually rebuild after upgrading Go.
+	goroot := []byte(runtime.GOROOT() + "/")
+	gomodroot := []byte(filepath.Join(build.Default.GOPATH, "pkg/mod") + "/")
+
+	w := bufio.NewWriter(depf)
+	fmt.Fprintf(w, "%s:", outpath)
+	s := bufio.NewScanner(&buf)
+	s.Split(bufio.ScanWords)
+	for s.Scan() {
+		dep := bytes.TrimSpace(s.Bytes())
+		if bytes.HasPrefix(dep, goroot) || bytes.HasPrefix(dep, gomodroot) {
+			continue
 		}
+		w.WriteRune(' ')
+		w.Write(dep)
 	}
-	deps = append(deps, '\n')
-	_, err = depf.Write(deps)
-	return err
+	w.WriteRune('\n')
+	return w.Flush()
 }


### PR DESCRIPTION
While the goroot files change if you upgrade the Go version, there's
just so many of them that depending on them all is affecting seb
runtime. Thus I think it's a good trade-off to not put them in the
depfile.

I explored skipping the go list command and use build.Import directly,
but it turns out this runs go list regardless, so it was mostly
pointless and much slower.