### PR TITLE
Fix gobuild to work even in the top directory.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 go:
 - "1.12.x"
 
-dist: trusty
+dist: bionic
 addons:
   apt:
     packages:

--- a/internal/cmd/gobuild/gobuild.go
+++ b/internal/cmd/gobuild/gobuild.go
@@ -56,8 +56,7 @@ func Main(args ...string) {
 	outpath = flagset.Arg(1)
 	depfile = flagset.Arg(2)
 	if inpath == "" {
-		flagset.Usage()
-		os.Exit(2)
+		inpath = "."
 	}
 	if outpath == "" && needOutpath(*mode) {
 		flagset.Usage()

--- a/test/Builddesc
+++ b/test/Builddesc
@@ -48,3 +48,7 @@ INSTALL(/regress/multitgt
 		check_order::a,b,c
 	]
 )
+
+GOPROG(test-remote
+	gopkg[github.com/schibsted/sebuild/cmd/seb]
+)


### PR DESCRIPTION
Most commonly used to install remote go binaries, so I made the test do
that. Gobuild should simply treat empty input path as the current
directory.