### PR TITLE
Try to re-exec seb if plugin.Open report "previous failure".

### DIFF
--- a/cmd/seb/plugin_dso.go
+++ b/cmd/seb/plugin_dso.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path"
@@ -56,5 +57,12 @@ func BuildPlugin(ops *buildbuild.GlobalOps, ppath string) error {
 		return err
 	}
 	_, err = plugin.Open(binpath)
+	if err != nil && strings.Contains(err.Error(), "previous failure") {
+		if !ops.Options.Quiet {
+			fmt.Fprintln(os.Stderr, err)
+			fmt.Fprintln(os.Stderr, `Trying again due to "previous failure".`)
+		}
+		err = buildbuild.ErrNeedReExec
+	}
 	return err
 }


### PR DESCRIPTION
As plugins are never unloaded, some failures are permanent and trying to
Open again just reports the same error, most commonly because of builing
against a slightly different package.

Try to re-exec in this case to clean the state and hopefully load the
plugin in the new binary.