### PR TITLE
Add a <flavor>/gocover target to generate all coverage reports.

### DIFF
--- a/docs/descriptors/gotest.md
+++ b/docs/descriptors/gotest.md
@@ -17,7 +17,7 @@ To allow to run go test via ninja, for each GOTEST descriptor a target
 test. In addition, you can also run `go test -cover` to generate an html file
 with this target:
 
-    build/<flavor>/gocover/<name>-coverage.html
+    build/<flavor>/gocover/<name>.html
 
 And also `go test -bench` with
 
@@ -39,3 +39,9 @@ information about this.
 Unfortunately, the go coverage html generating does not currently work in other
 go modules than the main one. There is no easy way to solve this so it's kept
 as a known issue.
+
+To easily generate all go coverage report, the target
+
+    build/<flavor>/gocover
+
+maps to the list of reports and can be used to generate all of them.

--- a/pkg/buildbuild/go.go
+++ b/pkg/buildbuild/go.go
@@ -124,8 +124,10 @@ func (g *GoTestDesc) Finalize(ops *GlobalOps) {
 	target = g.AddTarget("gocover/"+name+"-coverage", "gocover", []string{g.Srcdir}, "destroot", "", eas, opts)
 	AddGodeps(target, ops)
 
-	target = g.AddTarget("gocover/"+name+"-coverage.html", "gocover_html", []string{"gocover/" + name + "-coverage"}, "destroot", "", eas, nil)
+	target = g.AddTarget("gocover/"+name+".html", "gocover_html", []string{"gocover/" + name + "-coverage"}, "destroot", "", eas, nil)
 	target.CollectAs = "_gocover"
+
+	g.AddTarget("gocover/"+name+"-coverage.html", "gocover_html", []string{"gocover/" + name + "-coverage"}, "destroot", "", eas, nil)
 
 	if g.Benchflags != "" {
 		eas = append(eas, "benchflags="+g.Benchflags)

--- a/pkg/buildbuild/output.go
+++ b/pkg/buildbuild/output.go
@@ -233,6 +233,7 @@ func (ops *GlobalOps) OutputFlavor(topdir, flavor string) {
 		fmt.Fprintf(w, " %s/%s", builddir, an.TargetName)
 	}
 	w.WriteByte('\n')
+	fmt.Fprintf(w, "build %s/gocover: phony %s\n", destdir, strings.Join(ops.CollectedVars["_gocover"], " "))
 
 	fmt.Fprintf(w, "build %s: phony %s\n", flavor, strings.Join(defaults, " "))
 


### PR DESCRIPTION
Also changed the primary name to simply be <gotestname>.html. Since the
old name also still works this shouldn't be a breaking change.