### PR TITLE
Add the compiler flavor as a condition.

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -11,9 +11,9 @@ example could look like this:
 		includes[rand.h]
 	)
 
-Sources are only added if both conditions `linux` and `x86_64` are set.  Two
-conditions are always added: lowercase output of `uname` and output of `uname
--m`. For example `linux` and `x86_64`.
+Sources are only added if both conditions `linux` and `x86_64` are set. Three
+conditions are always added: lowercase output of `uname`, output of `uname
+-m` and the compiler flavor. For example `linux`, `x86_64` and `gcc`.
 
 Condition checks can be negated by prefixing them with a bang (`!`). Then
 the check is successful if the condition is NOT set.

--- a/pkg/buildbuild/args_test.go
+++ b/pkg/buildbuild/args_test.go
@@ -68,7 +68,16 @@ func testParseArgs(args *Args, s *Scanner, conds map[string]bool) (haveEnabled b
 			err = p.(error)
 		}
 	}()
-	return args.Parse(s, conds), nil
+	checkConds := func(condstr string) bool {
+		for _, c := range strings.Split(condstr, ",") {
+			condval, c := parseCond(c)
+			if conds[c] != condval {
+				return false
+			}
+		}
+		return true
+	}
+	return args.Parse(s, checkConds), nil
 }
 
 func TestArgs(t *testing.T) {

--- a/pkg/buildbuild/compile.go
+++ b/pkg/buildbuild/compile.go
@@ -121,6 +121,10 @@ func (l *LinkDesc) CompileSrc(srcdir, src, srcbase, ext string) {
 var findCompilerRun = (*exec.Cmd).Run
 
 func (ops *GlobalOps) FindCompilerCC() error {
+	if ops.didFindCompiler {
+		return nil
+	}
+	ops.didFindCompiler = true
 	candidates := ops.Config.Compiler
 	envcc := os.Getenv("CC")
 	if envcc != "" {

--- a/pkg/buildbuild/component.go
+++ b/pkg/buildbuild/component.go
@@ -90,7 +90,7 @@ func (dp *DescParser) Parse(srcdir string, s *Scanner, flavors []string) ParseFu
 	tname := s.Text()
 
 	var args Args
-	haveEnabled := args.Parse(s, dp.Ops.Config.Conditions)
+	haveEnabled := args.Parse(s, dp.Ops.CheckConditions)
 
 	if flavors == nil {
 		flavors = dp.Ops.Config.ActiveFlavors
@@ -142,7 +142,7 @@ func (ops *GlobalOps) ParseDescriptorEnd(srcdir string, s *Scanner, flavors []st
 
 func (ops *GlobalOps) ParseComponent(srcdir string, s *Scanner, flavors []string) ParseFunc {
 	var args Args
-	args.Parse(s, ops.Config.Conditions)
+	args.Parse(s, ops.CheckConditions)
 	if args.Unflavored["flavors"] != nil {
 		flavors = args.Unflavored["flavors"]
 	}

--- a/pkg/buildbuild/descriptor.go
+++ b/pkg/buildbuild/descriptor.go
@@ -129,7 +129,7 @@ func (g *GeneralDesc) GenericParse(desc Descriptor, ops *GlobalOps, realsrcdir s
 			panic(err)
 		}
 		var incargs Args
-		incargs.Parse(s, ops.Config.Conditions)
+		incargs.Parse(s, ops.CheckConditions)
 		s.Close()
 		parentbd := g.Builddesc
 		g.Builddesc = inc

--- a/pkg/buildbuild/globalops.go
+++ b/pkg/buildbuild/globalops.go
@@ -52,6 +52,8 @@ type GlobalOps struct {
 	Config        Config
 	FlavorConfigs map[string]*FlavorConfig
 
+	didFindCompiler bool
+
 	// If non-nil, called after parsing CONFIG.
 	PostConfigFunc func(ops *GlobalOps) error
 

--- a/pkg/buildbuild/output.go
+++ b/pkg/buildbuild/output.go
@@ -75,6 +75,7 @@ func (ops *GlobalOps) OutputTop() (err error) {
 	for c := range ops.Config.Conditions {
 		conds = append(conds, c)
 	}
+	conds = append(conds, ops.CompilerFlavor)
 	sort.Strings(conds)
 	fmt.Fprintf(w, "# Conditions: %s\n", strings.Join(conds, ", "))
 
@@ -267,6 +268,7 @@ dest_lib=$destroot/lib
 	for c := range ops.Config.Conditions {
 		conds = append(conds, c)
 	}
+	conds = append(conds, ops.CompilerFlavor)
 	sort.Strings(conds)
 	for _, c := range conds {
 		fmt.Fprintf(&bvbuf, "%s=1\n", c)


### PR DESCRIPTION
This allows setting e.g. warning flags that's only supported on one
flavor directly in the Builddesc. Before a compiler flavor specific
ninja file had to be used with a ninja variable.