### PR TITLE
Fixes to run with go 1.16.

### DIFF
--- a/internal/cmd/gobuild/archive.go
+++ b/internal/cmd/gobuild/archive.go
@@ -21,9 +21,9 @@ func buildCArchive(mode string, ldflags []string) {
 
 	if mode == "piclib" {
 		// -a to build standard libs with -shared
-		executeWithLdFlagsAndPkg(ldflags, "go", "build", "-i", "-pkgdir", abspkgdir+"/gopkg_piclib", "-installsuffix=piclib", "-buildmode=c-archive", "-gcflags=-shared", "-asmflags=-shared", "-a", "-o", absout)
+		executeWithLdFlagsAndPkg(ldflags, "go", "build", "-pkgdir", abspkgdir+"/gopkg_piclib", "-installsuffix=piclib", "-buildmode=c-archive", "-gcflags=-shared", "-asmflags=-shared", "-a", "-o", absout)
 	} else {
-		executeWithLdFlagsAndPkg(ldflags, "go", "build", "-i", "-pkgdir", abspkgdir+"/gopkg_lib", "-installsuffix=lib", "-buildmode=c-archive", "-o", absout)
+		executeWithLdFlagsAndPkg(ldflags, "go", "build", "-pkgdir", abspkgdir+"/gopkg_lib", "-installsuffix=lib", "-buildmode=c-archive", "-o", absout)
 	}
 
 	// If there weren't any exports the header won't be created, but we expect it to be there.

--- a/test/compile.sh
+++ b/test/compile.sh
@@ -2,7 +2,7 @@
 # Copyright 2018 Schibsted
 
 set -xe
-test -z "$BUILDPATH" && BUILDPATH=build
+export BUILDPATH=build
 
 CC="cc -std=gnu11" seb -condition cfoo -condition cbar
 touch Builddesc # to make ninja invoke seb.
@@ -17,7 +17,7 @@ grep -q bar $BUILDPATH/obj/regress/lib/test
 grep -q fooval $BUILDPATH/regress/regress/infile/infile
 
 # Check regress flavor for darwin 386 build
-grep -q rt0_386_darwin $BUILDPATH/regress/bin/goarch
+grep -q rt0_386_openbsd $BUILDPATH/regress/bin/goarch
 # Check prod flavor is executable.
 $BUILDPATH/prod/bin/goarch
 

--- a/test/goarch/Builddesc
+++ b/test/goarch/Builddesc
@@ -1,6 +1,6 @@
 GOPROG(goarch
 	goarch:regress[386]
-	goos:regress[darwin]
+	goos:regress[openbsd]
 )
 
 GOTEST(goarch


### PR DESCRIPTION
Stop using the deprecated -i flag, it's not really needed.

Set BUILDPATH explicitly for tests to avoid users having values .build
that fails to work with generated Go code.

Stop using removed darwin/386 arch to test cross compiling.